### PR TITLE
Update Scala 2.13 version to M3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ scala:
 - 2.10.7
 - 2.11.12
 - 2.12.4
-- 2.13.0-M2
+- 2.13.0-M3
 jdk:
 - oraclejdk8
 - oraclejdk9

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ organization := "com.typesafe.play"
 
 scalaVersion := "2.12.4"
 
-crossScalaVersions := Seq("2.12.4", "2.11.12", "2.10.7", "2.13.0-M2")
+crossScalaVersions := Seq("2.12.4", "2.11.12", "2.10.7", "2.13.0-M3")
 
 libraryDependencies := {
   CrossVersion.partialVersion(scalaVersion.value) match {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,13 +5,13 @@ import sbt._
 
 object Dependencies {
 
-  val scalaTestVersion = "3.0.4"
+  val scalaTestVersion = "3.0.5-M1"
 
   val scalaTest = Seq(
     "org.scalatest" %% "scalatest" % scalaTestVersion % "test"
   )
 
-  val parserCombinatorVersion = "1.0.6"
+  val parserCombinatorVersion = "1.1.0"
   val parserCombinators = Seq(
     "org.scala-lang.modules" %% "scala-parser-combinators" % parserCombinatorVersion
   )


### PR DESCRIPTION
Keeping on track with Scala 2.13 release.

See https://github.com/playframework/playframework/issues/7940.