### PR TITLE
remove joda-time and joda-convert in favor of java.time

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ libraryDependencies := {
   }
 }
 
-libraryDependencies ++= scalaTest ++ jodaTime ++ slf4j
+libraryDependencies ++= scalaTest ++ slf4j
 
 libraryDependencies += "org.slf4j" % "slf4j-simple" % slf4jVersion % Test
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,9 +21,4 @@ object Dependencies {
     "org.slf4j" % "slf4j-api" % slf4jVersion
   )
 
-  val jodaTime = Seq(
-    "joda-time" % "joda-time" % "2.9.9",
-    "org.joda" % "joda-convert" % "1.9.2"
-  )
-
 }

--- a/src/main/scala/com/typesafe/play/cachecontrol/Cache.scala
+++ b/src/main/scala/com/typesafe/play/cachecontrol/Cache.scala
@@ -5,7 +5,6 @@
 package com.typesafe.play.cachecontrol
 
 import CacheDirectives.CacheDirectiveExtension
-import org.joda.time.Seconds
 
 /**
  * This trait defines methods that are used through the library where core business logic

--- a/src/main/scala/com/typesafe/play/cachecontrol/CacheDirectiveParser.scala
+++ b/src/main/scala/com/typesafe/play/cachecontrol/CacheDirectiveParser.scala
@@ -3,7 +3,6 @@
  */
 package com.typesafe.play.cachecontrol
 
-import org.joda.time.Seconds
 import org.slf4j.LoggerFactory
 
 import scala.collection.immutable.BitSet
@@ -86,7 +85,7 @@ object CacheDirectiveParser {
 
     def seconds(n: String): Seconds = {
       val unquoted = s"PT${n}S"
-      Seconds.parseSeconds(unquoted)
+      Seconds.parse(unquoted)
     }
 
     //   cache-directive = token [ "=" ( token / quoted-string ) ]

--- a/src/main/scala/com/typesafe/play/cachecontrol/CacheDirectives.scala
+++ b/src/main/scala/com/typesafe/play/cachecontrol/CacheDirectives.scala
@@ -3,8 +3,6 @@
  */
 package com.typesafe.play.cachecontrol
 
-import org.joda.time.Seconds
-
 /**
  * A trait that marks the cache directives generated
  * from parsing a cache-control header.
@@ -18,7 +16,7 @@ object CacheDirectives {
   // https://tools.ietf.org/html/rfc7234#section-5.2.2.8
   // https://tools.ietf.org/html/rfc7234#section-5.2.1.1
   case class MaxAge(delta: Seconds) extends CacheDirective {
-    override def toString: String = s"max-age=${delta.getSeconds}"
+    override def toString: String = s"max-age=${delta.seconds}"
   }
 
   /**
@@ -52,7 +50,7 @@ object CacheDirectives {
     override def toString: String = {
       delta match {
         case Some(d) =>
-          s"max-stale=${d.getSeconds}"
+          s"max-stale=${d.seconds}"
         case None =>
           "max-stale"
       }
@@ -70,7 +68,7 @@ object CacheDirectives {
 
   // https://tools.ietf.org/html/rfc7234#section-5.2.1.3
   case class MinFresh(delta: Seconds) extends CacheDirective {
-    override def toString: String = s"min-fresh=${delta.getSeconds}"
+    override def toString: String = s"min-fresh=${delta.seconds}"
   }
 
   def minFresh(directives: scala.collection.immutable.Seq[CacheDirective]): Option[MinFresh] = {
@@ -184,7 +182,7 @@ object CacheDirectives {
 
   // https://tools.ietf.org/html/rfc7234#section-5.2.2.9
   case class SMaxAge(delta: Seconds) extends CacheDirective {
-    override def toString: String = s"s-maxage=${delta.getSeconds}"
+    override def toString: String = s"s-maxage=${delta.seconds}"
   }
 
   def sMaxAge(directives: scala.collection.immutable.Seq[CacheDirective]): Option[SMaxAge] = {
@@ -198,7 +196,7 @@ object CacheDirectives {
 
   // https://tools.ietf.org/html/rfc5861#section-3
   case class StaleWhileRevalidate(delta: Seconds) extends CacheDirective {
-    override def toString: String = s"stale-while-revalidate=${delta.getSeconds}"
+    override def toString: String = s"stale-while-revalidate=${delta.seconds}"
   }
 
   def staleWhileRevalidate(directives: scala.collection.immutable.Seq[CacheDirective]): Option[StaleWhileRevalidate] = {
@@ -212,7 +210,7 @@ object CacheDirectives {
 
   // https://tools.ietf.org/html/rfc5861#section-4
   case class StaleIfError(delta: Seconds) extends CacheDirective {
-    override def toString: String = s"stale-if-error=${delta.getSeconds}"
+    override def toString: String = s"stale-if-error=${delta.seconds}"
   }
 
   def staleIfError(directives: scala.collection.immutable.Seq[CacheDirective]): Option[StaleIfError] = {

--- a/src/main/scala/com/typesafe/play/cachecontrol/FreshnessCalculator.scala
+++ b/src/main/scala/com/typesafe/play/cachecontrol/FreshnessCalculator.scala
@@ -4,7 +4,6 @@
 package com.typesafe.play.cachecontrol
 
 import CacheDirectives.SMaxAge
-import org.joda.time.Seconds
 import org.slf4j.LoggerFactory
 
 /**
@@ -62,7 +61,7 @@ class FreshnessCalculator(cache: Cache) {
     }
 
     val result = maybeResult.getOrElse {
-      Seconds.seconds(0)
+      Seconds.ZERO
     }
     logger.debug(s"calculateFreshnessLifetime: result = $result")
     result

--- a/src/main/scala/com/typesafe/play/cachecontrol/HttpDate.scala
+++ b/src/main/scala/com/typesafe/play/cachecontrol/HttpDate.scala
@@ -35,7 +35,7 @@ object HttpDate {
       .appendLiteral(EMPTY)
       .appendPattern("dd-MMM-")
       // Pivot Year:
-      // https://github.com/JodaOrg/joda-time/blob/master/src/main/java/org/joda/time/format/DateTimeFormat.java#L455
+      // https://tools.ietf.org/html/rfc6265#section-5.1.1
       .appendValueReduced(ChronoField.YEAR, 2, 2, 1970)
       .appendLiteral(EMPTY)
       .appendPattern("HH:mm:ss")
@@ -103,8 +103,8 @@ object HttpDate {
     // than 50 years in the future as representing the most recent year in
     // the past that had the same last two digits.
     // -- java.time needs to handle 'Sunday' and 'Sun' with different date formatters and
-    // we need to provide a pivot year like yoda does:
-    // https://github.com/JodaOrg/joda-time/blob/master/src/main/java/org/joda/time/format/DateTimeFormat.java#L455
+    // we need to provide a pivot year like explained in the following RFC:
+    // https://tools.ietf.org/html/rfc6265#section-5.1.1
 
     Try {
       ZonedDateTime.parse(dateString, rfc850Format("EEE"))

--- a/src/main/scala/com/typesafe/play/cachecontrol/HttpDate.scala
+++ b/src/main/scala/com/typesafe/play/cachecontrol/HttpDate.scala
@@ -8,6 +8,7 @@ import java.time.temporal.ChronoField
 import java.time._
 
 import scala.util.Try
+import scala.util.control.NonFatal
 
 /**
  * Defines methods for parsing and formatting HTTP dates.
@@ -106,11 +107,11 @@ object HttpDate {
     // we need to provide a pivot year like explained in the following RFC:
     // https://tools.ietf.org/html/rfc6265#section-5.1.1
 
-    Try {
+    try {
       ZonedDateTime.parse(dateString, rfc850Format("EEE"))
-    }.recover {
-      case _ => ZonedDateTime.parse(dateString, rfc850Format("EEEE"))
-    }.get
+    } catch {
+      case NonFatal(_) => ZonedDateTime.parse(dateString, rfc850Format("EEEE"))
+    }
   }
 
   /**

--- a/src/main/scala/com/typesafe/play/cachecontrol/HttpDate.scala
+++ b/src/main/scala/com/typesafe/play/cachecontrol/HttpDate.scala
@@ -36,7 +36,7 @@ object HttpDate {
       .appendPattern("dd-MMM-")
       // Pivot Year:
       // https://github.com/JodaOrg/joda-time/blob/master/src/main/java/org/joda/time/format/DateTimeFormat.java#L455
-      .appendValueReduced(ChronoField.YEAR, 2, 2, Year.now().getValue - 30)
+      .appendValueReduced(ChronoField.YEAR, 2, 2, 1970)
       .appendLiteral(EMPTY)
       .appendPattern("HH:mm:ss")
       .appendLiteral(EMPTY)

--- a/src/main/scala/com/typesafe/play/cachecontrol/ResponseCachingCalculator.scala
+++ b/src/main/scala/com/typesafe/play/cachecontrol/ResponseCachingCalculator.scala
@@ -5,8 +5,6 @@ package com.typesafe.play.cachecontrol
 
 import org.slf4j.LoggerFactory
 
-import scala.collection.immutable.Seq
-
 sealed trait ResponseCachingAction
 
 /**

--- a/src/main/scala/com/typesafe/play/cachecontrol/ResponseSelectionCalculator.scala
+++ b/src/main/scala/com/typesafe/play/cachecontrol/ResponseSelectionCalculator.scala
@@ -3,9 +3,10 @@
  */
 package com.typesafe.play.cachecontrol
 
+import java.time.ZonedDateTime
+
 import CacheDirectives.OnlyIfCached
 import HeaderNames._
-import org.joda.time.DateTime
 import org.slf4j.LoggerFactory
 
 sealed trait ResponseSelectionAction
@@ -87,7 +88,7 @@ class ResponseSelectionCalculator(cache: Cache) {
     }
   }
 
-  def toDate(r: StoredResponse): DateTime = {
+  def toDate(r: StoredResponse): ZonedDateTime = {
     HttpDate.parse(r.headers(`Date`).head)
   }
 

--- a/src/main/scala/com/typesafe/play/cachecontrol/Seconds.scala
+++ b/src/main/scala/com/typesafe/play/cachecontrol/Seconds.scala
@@ -1,0 +1,217 @@
+/*
+ * Copyright (C) 2015-2018 Lightbend, Inc. All rights reserved.
+ */
+package com.typesafe.play.cachecontrol
+
+import java.time.{ DateTimeException, Duration }
+import java.time.temporal.{ Temporal, TemporalAmount, TemporalUnit, UnsupportedTemporalTypeException }
+import java.util
+
+import scala.language.implicitConversions
+
+/**
+ * An immutable time period representing a number of seconds.
+ */
+case class Seconds private (duration: Duration) extends TemporalAmount {
+
+  /**
+   * Gets the number of seconds that this period represents.
+   *
+   * @return the number of seconds in the period
+   */
+  def seconds: Long = duration.getSeconds
+
+  /**
+   * Returns a new instance with the specified number of seconds added.
+   * <p>
+   * This instance is immutable and unaffected by this method call.
+   *
+   * @param other  the amount of seconds to add, may be negative, null means zero
+   * @return the new period plus the specified number of seconds
+   * @throws ArithmeticException if the result overflows an int
+   */
+  def plus(other: Seconds): Seconds =
+    Seconds.ofDuration(duration.plus(other.duration))
+
+  /**
+   * Returns a new instance with the specified number of seconds taken away.
+   * <p>
+   * This instance is immutable and unaffected by this method call.
+   *
+   * @param other  the amount of seconds to take away, may be negative, null means zero
+   * @return the new period minus the specified number of seconds
+   * @throws ArithmeticException if the result overflows an int
+   */
+  def minus(other: Seconds): Seconds =
+    Seconds.ofDuration(duration.minus(other.duration))
+
+  /**
+   * Is this seconds instance less than the specified number of seconds.
+   *
+   * @param other  the other period, null means zero
+   * @return true if this seconds instance is less than the specified one
+   */
+  def isLessThan(other: Seconds): Boolean =
+    duration.compareTo(other.duration) < 0
+
+  /**
+   * Is this seconds instance greater than the specified number of seconds.
+   *
+   * @param other  the other period, null means zero
+   * @return true if this seconds instance is greater than the specified one
+   */
+  def isGreaterThan(other: Seconds): Boolean =
+    duration.compareTo(other.duration) > 0
+
+  /**
+   * Gets this instance as a String in the ISO8601 duration format.
+   * <p>
+   * For example, "PT4S" represents 4 seconds.
+   *
+   * @return the value as an ISO8601 string
+   */
+  override def toString: String = s"PT${seconds}S"
+
+  // shims to calculate with other java8 apis
+
+  /**
+   * Gets the value of the requested unit.
+   * <p>
+   * This returns a value for each of the two supported units,
+   * {@link ChronoUnit#SECONDS SECONDS} and {@link ChronoUnit#NANOS NANOS}.
+   * All other units throw an exception.
+   *
+   * @param unit the { @code TemporalUnit} for which to return the value
+   * @return the long value of the unit
+   * @throws DateTimeException if the unit is not supported
+   * @throws UnsupportedTemporalTypeException if the unit is not supported
+   */
+  override def get(unit: TemporalUnit): Long = duration.get(unit)
+  /**
+   * Subtracts this duration from the specified temporal object.
+   * <p>
+   * This returns a temporal object of the same observable type as the input
+   * with this duration subtracted.
+   * <p>
+   * In most cases, it is clearer to reverse the calling pattern by using
+   * {@link Temporal#minus(TemporalAmount)}.
+   * <pre>
+   *   // these two lines are equivalent, but the second approach is recommended
+   *   dateTime = thisDuration.subtractFrom(dateTime);
+   *   dateTime = dateTime.minus(thisDuration);
+   * </pre>
+   * <p>
+   * The calculation will subtract the seconds, then nanos.
+   * Only non-zero amounts will be added.
+   * <p>
+   * This instance is immutable and unaffected by this method call.
+   *
+   * @param temporal  the temporal object to adjust, not null
+   * @return an object of the same type with the adjustment made, not null
+   * @throws DateTimeException if unable to subtract
+   * @throws ArithmeticException if numeric overflow occurs
+   */
+  override def subtractFrom(temporal: Temporal): Temporal = duration.subtractFrom(temporal)
+
+  /**
+   * Gets the set of units supported by this duration.
+   * <p>
+   * The supported units are {@link ChronoUnit#SECONDS SECONDS},
+   * and {@link ChronoUnit#NANOS NANOS}.
+   * They are returned in the order seconds, nanos.
+   * <p>
+   * This set can be used in conjunction with {@link #get(TemporalUnit)}
+   * to access the entire state of the duration.
+   *
+   * @return a list containing the seconds and nanos units, not null
+   */
+  override def getUnits: util.List[TemporalUnit] = duration.getUnits
+
+  /**
+   * Adds this duration to the specified temporal object.
+   * <p>
+   * This returns a temporal object of the same observable type as the input
+   * with this duration added.
+   * <p>
+   * In most cases, it is clearer to reverse the calling pattern by using
+   * {@link Temporal#plus(TemporalAmount)}.
+   * <pre>
+   *   // these two lines are equivalent, but the second approach is recommended
+   *   dateTime = thisDuration.addTo(dateTime);
+   *   dateTime = dateTime.plus(thisDuration);
+   * </pre>
+   * <p>
+   * The calculation will add the seconds, then nanos.
+   * Only non-zero amounts will be added.
+   * <p>
+   * This instance is immutable and unaffected by this method call.
+   *
+   * @param temporal  the temporal object to adjust, not null
+   * @return an object of the same type with the adjustment made, not null
+   * @throws DateTimeException if unable to add
+   * @throws ArithmeticException if numeric overflow occurs
+   */
+  override def addTo(temporal: Temporal): Temporal = duration.addTo(temporal)
+
+}
+
+object Seconds {
+
+  /** implicit that will only use the seconds part of a duration */
+  implicit def fromDurationToSecond(duration: Duration): Seconds = {
+    Seconds.seconds(duration.getSeconds)
+  }
+
+  /** Constant representing zero seconds. */
+  val ZERO: Seconds = Seconds.ofDuration(Duration.ZERO)
+
+  /**
+   * Creates a [[Seconds]] representing the number of whole seconds
+   * between the two specified datetimes.
+   *
+   * @param startInclusive  the start instant, must not be null
+   * @param endInclusive  the end instant, must not be null
+   * @return the period in seconds
+   * @throws IllegalArgumentException if the instants are null or invalid
+   */
+  def between(startInclusive: Temporal, endInclusive: Temporal): Seconds = {
+    Seconds.seconds(Duration.between(startInclusive, endInclusive).getSeconds)
+  }
+
+  /**
+   * Obtains an instance of [[Seconds]].
+   * This will actually only use the seconds of a [[java.time.Duration]].
+   *
+   * @param duration the duration
+   * @return the instance of Seconds
+   */
+  def ofDuration(duration: Duration): Seconds = {
+    new Seconds(Duration.ofSeconds(duration.getSeconds))
+  }
+
+  /**
+   * Obtains an instance of [[Seconds]].
+   *
+   * @param seconds  the number of seconds to obtain an instance for
+   * @return the instance of Seconds
+   */
+  def seconds(seconds: Long): Seconds = {
+    new Seconds(Duration.ofSeconds(seconds))
+  }
+
+  /**
+   * Creates a new [[Seconds]] by parsing a string in the ISO8601 format 'PTnS'.
+   * <p>
+   * The parse will accept the full ISO syntax of PnYnMnWnDTnHnMnS however only the
+   * seconds component may be non-zero. If any other component is non-zero, an exception
+   * will be thrown.
+   *
+   * @param periodStr  the period string, null returns zero
+   * @return the period in seconds
+   * @throws IllegalArgumentException if the string format is invalid
+   */
+  def parse(periodStr: String): Seconds = {
+    new Seconds(Duration.ofSeconds(Duration.parse(periodStr).getSeconds))
+  }
+
+}

--- a/src/main/scala/com/typesafe/play/cachecontrol/Warning.scala
+++ b/src/main/scala/com/typesafe/play/cachecontrol/Warning.scala
@@ -3,12 +3,12 @@
  */
 package com.typesafe.play.cachecontrol
 
-import org.joda.time.DateTime
+import java.time.ZonedDateTime
 
 /**
  * A parsed warning.
  */
-case class Warning(code: Int, agent: String, text: String, date: Option[DateTime] = None) {
+case class Warning(code: Int, agent: String, text: String, date: Option[ZonedDateTime] = None) {
   override def toString: String = {
     date.map { d =>
       val httpDate = HttpDate.format(d)

--- a/src/test/scala/com/typesafe/play/cachecontrol/CacheDirectiveParserSpec.scala
+++ b/src/test/scala/com/typesafe/play/cachecontrol/CacheDirectiveParserSpec.scala
@@ -3,7 +3,6 @@
  */
 package com.typesafe.play.cachecontrol
 
-import org.joda.time.Seconds
 import org.scalatest.WordSpec
 import org.scalatest.Matchers._
 

--- a/src/test/scala/com/typesafe/play/cachecontrol/CurrentAgeCalculatorSpec.scala
+++ b/src/test/scala/com/typesafe/play/cachecontrol/CurrentAgeCalculatorSpec.scala
@@ -5,7 +5,6 @@ package com.typesafe.play.cachecontrol
 
 import java.net.URI
 
-import org.joda.time._
 import org.scalatest.WordSpec
 import org.scalatest.Matchers._
 import HeaderNames._
@@ -13,7 +12,7 @@ import HeaderNames._
 class CurrentAgeCalculatorSpec extends WordSpec {
 
   val ageCalculator = new CurrentAgeCalculator()
-  val zeroSeconds = org.joda.time.Seconds.seconds(0)
+  val zeroSeconds = Seconds.seconds(0)
 
   def defaultResponse(age: Int) = {
     val uri = new URI("http://example.com/data")
@@ -23,7 +22,7 @@ class CurrentAgeCalculatorSpec extends WordSpec {
     val ageSeconds = Seconds.seconds(60)
     val headers = Map(
       `Date` -> Seq(HttpDate.format(now)),
-      `Age` -> Seq(ageSeconds.getSeconds.toString))
+      `Age` -> Seq(ageSeconds.seconds.toString))
     StoredResponse(uri, status, headers, requestMethod, Map())
   }
 
@@ -34,7 +33,7 @@ class CurrentAgeCalculatorSpec extends WordSpec {
       val ageSeconds = Seconds.seconds(60)
       val headers = Map(
         `Date` -> Seq(HttpDate.format(now)),
-        `Age` -> Seq(ageSeconds.getSeconds.toString))
+        `Age` -> Seq(ageSeconds.seconds.toString))
 
       val seconds = ageCalculator.calculateAgeValue(headers)
       seconds should be(ageSeconds)
@@ -53,7 +52,7 @@ class CurrentAgeCalculatorSpec extends WordSpec {
 
     "calculate age from Date header" in {
       val ageSeconds = Seconds.seconds(60)
-      val date = HttpDate.now.minus(ageSeconds.toStandardDuration)
+      val date = HttpDate.now.minus(ageSeconds)
       val headers = Map(
         `Date` -> Seq(HttpDate.format(date)))
 
@@ -115,7 +114,7 @@ class CurrentAgeCalculatorSpec extends WordSpec {
       val responseTime = now
 
       val headers = Map(
-        `Age` -> Seq(originAge.getSeconds.toString),
+        `Age` -> Seq(originAge.seconds.toString),
         `Date` -> Seq(HttpDate.format(originDate)))
       val seconds = ageCalculator.calculateCurrentAge(headers, now, requestTime, responseTime)
       seconds should be(Seconds.seconds(60))
@@ -132,7 +131,7 @@ class CurrentAgeCalculatorSpec extends WordSpec {
       val responseTime = now
 
       val headers = Map(
-        `Age` -> Seq(originAge.getSeconds.toString),
+        `Age` -> Seq(originAge.seconds.toString),
         `Date` -> Seq(HttpDate.format(originDate)))
       val seconds = ageCalculator.calculateCurrentAge(headers, now, requestTime, responseTime)
       // The final content should be 62 seconds.

--- a/src/test/scala/com/typesafe/play/cachecontrol/FreshnessCalculatorSpec.scala
+++ b/src/test/scala/com/typesafe/play/cachecontrol/FreshnessCalculatorSpec.scala
@@ -6,7 +6,6 @@ package com.typesafe.play.cachecontrol
 import java.net.URI
 
 import HeaderNames._
-import org.joda.time.Seconds
 import org.scalatest.Matchers._
 import org.scalatest._
 

--- a/src/test/scala/com/typesafe/play/cachecontrol/HttpDateSpec.scala
+++ b/src/test/scala/com/typesafe/play/cachecontrol/HttpDateSpec.scala
@@ -3,10 +3,10 @@
  */
 package com.typesafe.play.cachecontrol
 
-import org.joda.time.format.DateTimeFormat
-import org.joda.time._
-import org.scalatest.{ TryValues, WordSpec }
+import java.time.format.DateTimeFormatter
+import java.time.{ ZoneOffset, ZonedDateTime }
 
+import org.scalatest.{ TryValues, WordSpec }
 import org.scalatest.MustMatchers
 
 /**
@@ -15,13 +15,13 @@ import org.scalatest.MustMatchers
 class HttpDateSpec extends WordSpec with TryValues with MustMatchers {
 
   "parse a date in IMF-fixdate format" in {
-    val expectedDate = new DateTime(1994, 11, 6, 8, 49, 37, DateTimeZone.forID("GMT"))
+    val expectedDate = ZonedDateTime.of(1994, 11, 6, 8, 49, 37, 0, HttpDate.zone)
     val dateString = "Sun, 06 Nov 1994 08:49:37 GMT"
     (HttpDate.parse(dateString)) must ===(expectedDate)
   }
 
   "parse a date in RFC 850 format" in {
-    val expectedDate = new DateTime(1994, 11, 6, 8, 49, 37, DateTimeZone.forID("GMT"))
+    val expectedDate = ZonedDateTime.of(1994, 11, 6, 8, 49, 37, 0, HttpDate.zone)
     val dateString = "Sunday, 06-Nov-94 08:49:37 GMT"
     HttpDate.parse(dateString) must ===(expectedDate)
 
@@ -29,32 +29,32 @@ class HttpDateSpec extends WordSpec with TryValues with MustMatchers {
 
   "parse a date that is > 50 years in the future correctly" in {
     pendingUntilFixed {
-      val rfc850Format = DateTimeFormat.forPattern("EEE, dd-MMM-yy HH:mm:ss 'GMT'")
+      val rfc850Format = DateTimeFormatter.ofPattern("EEE, dd-MMM-yy HH:mm:ss 'GMT'")
         .withLocale(java.util.Locale.ENGLISH)
-        .withZone(DateTimeZone.forID("GMT"))
+        .withZone(ZoneOffset.UTC)
 
       // 2166-11-06T08:49:37.000Z
-      val actualDate = new DateTime(2166, 11, 6, 8, 49, 37, DateTimeZone.forID("GMT"))
+      val actualDate = ZonedDateTime.of(2166, 11, 6, 8, 49, 37, 0, HttpDate.zone)
 
       // Thu, 06-Nov-66 08:49:37 GMT
-      val futureDateString = rfc850Format.print(actualDate)
+      val futureDateString = rfc850Format.format(actualDate)
 
       // 1966-11-06T08:49:37.000Z
-      val expectedDate = new DateTime(1966, 11, 6, 8, 49, 37, DateTimeZone.forID("GMT"))
+      val expectedDate = ZonedDateTime.of(1966, 11, 6, 8, 49, 37, 0, HttpDate.zone)
 
       HttpDate.parse(futureDateString) must ===(expectedDate)
     }
   }
 
   "parse a date in asctime format" in {
-    val expectedDate = new DateTime(1994, 11, 6, 8, 49, 37, DateTimeZone.forID("GMT"))
+    val expectedDate = ZonedDateTime.of(1994, 11, 6, 8, 49, 37, 0, HttpDate.zone)
     val dateString = "Sun Nov 6 08:49:37 1994"
     HttpDate.parse(dateString) must ===(expectedDate)
   }
 
   "format a date in IMF format" in {
     val expectedString = "Sun, 06 Nov 1994 08:49:37 GMT"
-    val date = new DateTime(1994, 11, 6, 8, 49, 37, DateTimeZone.forID("GMT"))
+    val date = ZonedDateTime.of(1994, 11, 6, 8, 49, 37, 0, HttpDate.zone)
     HttpDate.format(date) must ===(expectedString)
   }
 }

--- a/src/test/scala/com/typesafe/play/cachecontrol/ResponseSelectionCalculatorSpec.scala
+++ b/src/test/scala/com/typesafe/play/cachecontrol/ResponseSelectionCalculatorSpec.scala
@@ -7,8 +7,7 @@ import java.net.URI
 
 import CacheDirectives.CacheDirectiveExtension
 import HeaderNames._
-import ResponseSelectionActions.{ GatewayTimeout, SelectedResponse, ForwardToOrigin }
-import org.joda.time.Seconds
+import ResponseSelectionActions.{ ForwardToOrigin, GatewayTimeout, SelectedResponse }
 import org.scalatest.Matchers._
 import org.scalatest.WordSpec
 
@@ -24,7 +23,7 @@ class ResponseSelectionCalculatorSpec extends WordSpec {
     val date = HttpDate.now.minus(age)
     val headers = Map(
       `Date` -> Seq(HttpDate.format(date)),
-      `Age` -> Seq(age.getSeconds.toString))
+      `Age` -> Seq(age.seconds.toString))
     headers
   }
 

--- a/src/test/scala/com/typesafe/play/cachecontrol/ResponseServingcalculatorSpec.scala
+++ b/src/test/scala/com/typesafe/play/cachecontrol/ResponseServingcalculatorSpec.scala
@@ -4,9 +4,9 @@
 package com.typesafe.play.cachecontrol
 
 import java.net.URI
+import java.time.Duration
 
 import HeaderNames._
-import org.joda.time.Seconds
 import org.scalactic.ConversionCheckedTripleEquals
 import org.scalatest.Matchers._
 import org.scalatest.WordSpec
@@ -23,7 +23,7 @@ class ResponseServingCalculatorSpec extends WordSpec with ConversionCheckedTripl
     val status = 200
     val requestMethod = "GET"
     val now = HttpDate.now
-    val age = Seconds.seconds(60)
+    val age = Duration.ofSeconds(60)
     val headers = Map(
       `Date` -> Seq(HttpDate.format(now)),
       `Age` -> Seq(age.getSeconds.toString))
@@ -51,7 +51,7 @@ class ResponseServingCalculatorSpec extends WordSpec with ConversionCheckedTripl
         val request = defaultRequest.copy(headers = defaultRequest.headers ++ Map(`Cache-Control` -> Seq("no-cache")))
         val response = defaultResponse.copy(headers = defaultResponse.headers ++ Map(`Cache-Control` -> Seq("max-age=60")))
 
-        val action: ResponseServeAction = policy.serveResponse(request, response, Seconds.seconds(5))
+        val action: ResponseServeAction = policy.serveResponse(request, response, Duration.ofSeconds(5))
         val msg = "Fresh response: lifetime = PT60S, PT55S seconds left"
         action should be(ServeFresh(msg))
       }
@@ -62,7 +62,7 @@ class ResponseServingCalculatorSpec extends WordSpec with ConversionCheckedTripl
         val request = defaultRequest.copy(headers = defaultRequest.headers ++ Map(`Cache-Control` -> Seq("no-cache")))
         val response = defaultResponse.copy(headers = defaultResponse.headers ++ Map(`Cache-Control` -> Seq("max-age=60")))
 
-        val action: ResponseServeAction = policy.serveResponse(request, response, Seconds.seconds(65))
+        val action: ResponseServeAction = policy.serveResponse(request, response, Duration.ofSeconds(65))
         val msg = "Response is stale, and stale response is not allowed"
         action should be(Validate(msg))
       }
@@ -77,7 +77,7 @@ class ResponseServingCalculatorSpec extends WordSpec with ConversionCheckedTripl
         val request = defaultRequest.copy(headers = defaultRequest.headers ++ Map(`Cache-Control` -> Seq("no-store")))
         val response = defaultResponse.copy(headers = defaultResponse.headers ++ Map(`Cache-Control` -> Seq("publish,max-age=60")))
 
-        val action: ResponseServeAction = policy.serveResponse(request, response, Seconds.seconds(5))
+        val action: ResponseServeAction = policy.serveResponse(request, response, Duration.ofSeconds(5))
         val msg = "Fresh response: lifetime = PT60S, PT55S seconds left"
         action should be(ServeFresh(msg))
       }
@@ -88,7 +88,7 @@ class ResponseServingCalculatorSpec extends WordSpec with ConversionCheckedTripl
         val request = defaultRequest.copy(headers = defaultRequest.headers ++ Map(`Cache-Control` -> Seq("no-store")))
         val response = defaultResponse.copy(headers = defaultResponse.headers ++ Map(`Cache-Control` -> Seq("publish,max-age=60")))
 
-        val action: ResponseServeAction = policy.serveResponse(request, response, Seconds.seconds(60))
+        val action: ResponseServeAction = policy.serveResponse(request, response, Duration.ofSeconds(60))
         val msg = "Response is stale, and stale response is not allowed"
         action should be(Validate(msg))
       }
@@ -105,7 +105,7 @@ class ResponseServingCalculatorSpec extends WordSpec with ConversionCheckedTripl
         val responseHeaders = Map(`Cache-Control` -> Seq("public, max-age=10"))
         val response = defaultResponse.copy(headers = defaultResponse.headers ++ responseHeaders)
 
-        val action: ResponseServeAction = policy.serveResponse(request, response, Seconds.seconds(5))
+        val action: ResponseServeAction = policy.serveResponse(request, response, Duration.ofSeconds(5))
         action should be(ServeFresh("Fresh response: lifetime = PT10S, PT5S seconds left"))
       }
 
@@ -118,7 +118,7 @@ class ResponseServingCalculatorSpec extends WordSpec with ConversionCheckedTripl
         val responseHeaders = Map(`Cache-Control` -> Seq("public, max-age=10"))
         val response = defaultResponse.copy(headers = defaultResponse.headers ++ responseHeaders)
 
-        val action: ResponseServeAction = policy.serveResponse(request, response, Seconds.seconds(500))
+        val action: ResponseServeAction = policy.serveResponse(request, response, Duration.ofSeconds(500))
         action should be(ServeStale(s"Request contains no-args max-stale directive"))
       }
 
@@ -131,7 +131,7 @@ class ResponseServingCalculatorSpec extends WordSpec with ConversionCheckedTripl
         val responseHeaders = Map(`Cache-Control` -> Seq("public, max-age=10"))
         val response = defaultResponse.copy(headers = defaultResponse.headers ++ responseHeaders)
 
-        val action: ResponseServeAction = policy.serveResponse(request, response, Seconds.seconds(30))
+        val action: ResponseServeAction = policy.serveResponse(request, response, Duration.ofSeconds(30))
         action should be(ServeStale(s"Request contains max-stale=60, current age = 30 which is inside range"))
       }
 
@@ -144,7 +144,7 @@ class ResponseServingCalculatorSpec extends WordSpec with ConversionCheckedTripl
         val responseHeaders = Map(`Cache-Control` -> Seq("public, max-age=10"))
         val response = defaultResponse.copy(headers = defaultResponse.headers ++ responseHeaders)
 
-        val action: ResponseServeAction = policy.serveResponse(request, response, Seconds.seconds(120))
+        val action: ResponseServeAction = policy.serveResponse(request, response, Duration.ofSeconds(120))
         action should be(Validate(s"Response is stale, and stale response is not allowed"))
       }
     }
@@ -160,7 +160,7 @@ class ResponseServingCalculatorSpec extends WordSpec with ConversionCheckedTripl
         val responseHeaders = Map(`Cache-Control` -> Seq("public, max-age=120"))
         val response = defaultResponse.copy(headers = defaultResponse.headers ++ responseHeaders)
 
-        val action: ResponseServeAction = policy.serveResponse(request, response, Seconds.seconds(60))
+        val action: ResponseServeAction = policy.serveResponse(request, response, Duration.ofSeconds(60))
         action should be(Validate(s"Response is stale, and stale response is not allowed"))
       }
 
@@ -173,7 +173,7 @@ class ResponseServingCalculatorSpec extends WordSpec with ConversionCheckedTripl
         val responseHeaders = Map(`Cache-Control` -> Seq("public, max-age=120"))
         val response = defaultResponse.copy(headers = defaultResponse.headers ++ responseHeaders)
 
-        val action: ResponseServeAction = policy.serveResponse(request, response, Seconds.seconds(60))
+        val action: ResponseServeAction = policy.serveResponse(request, response, Duration.ofSeconds(60))
         action should be(ServeFresh(s"Fresh response: lifetime = PT120S, PT60S seconds left"))
       }
 
@@ -186,7 +186,7 @@ class ResponseServingCalculatorSpec extends WordSpec with ConversionCheckedTripl
         val responseHeaders = Map(`Cache-Control` -> Seq("public, max-age=120"))
         val response = defaultResponse.copy(headers = defaultResponse.headers ++ responseHeaders)
 
-        val action: ResponseServeAction = policy.serveResponse(request, response, Seconds.seconds(120))
+        val action: ResponseServeAction = policy.serveResponse(request, response, Duration.ofSeconds(120))
         action should be(Validate(s"Response is stale, and stale response is not allowed"))
       }
 
@@ -203,7 +203,7 @@ class ResponseServingCalculatorSpec extends WordSpec with ConversionCheckedTripl
         val responseHeaders = Map(`Cache-Control` -> Seq("public, max-age=120"))
         val response = defaultResponse.copy(headers = defaultResponse.headers ++ responseHeaders)
 
-        val action: ResponseServeAction = policy.serveResponse(request, response, Seconds.seconds(60))
+        val action: ResponseServeAction = policy.serveResponse(request, response, Duration.ofSeconds(60))
         action should be(ServeFresh(s"Fresh response: minFresh = PT60S, freshnessLifetime = PT120S, currentAge = PT60S"))
       }
 
@@ -216,7 +216,7 @@ class ResponseServingCalculatorSpec extends WordSpec with ConversionCheckedTripl
         val responseHeaders = Map(`Cache-Control` -> Seq("public, max-age=120"))
         val response = defaultResponse.copy(headers = defaultResponse.headers ++ responseHeaders)
 
-        val action: ResponseServeAction = policy.serveResponse(request, response, Seconds.seconds(120))
+        val action: ResponseServeAction = policy.serveResponse(request, response, Duration.ofSeconds(120))
         action should be(Validate(s"Response is stale, and stale response is not allowed"))
       }
 
@@ -229,7 +229,7 @@ class ResponseServingCalculatorSpec extends WordSpec with ConversionCheckedTripl
         val responseHeaders = Map(`Cache-Control` -> Seq("public, max-age=120"))
         val response = defaultResponse.copy(headers = defaultResponse.headers ++ responseHeaders)
 
-        val action: ResponseServeAction = policy.serveResponse(request, response, Seconds.seconds(60))
+        val action: ResponseServeAction = policy.serveResponse(request, response, Duration.ofSeconds(60))
         action should be(Validate(s"Response is stale, and stale response is not allowed"))
       }
     }
@@ -243,7 +243,7 @@ class ResponseServingCalculatorSpec extends WordSpec with ConversionCheckedTripl
         val responseHeaders = Map(`Cache-Control` -> Seq("max-age=10,stale-if-error=30"))
         val response = defaultResponse.copy(headers = defaultResponse.headers ++ responseHeaders)
 
-        val action: ResponseServeAction = policy.serveResponse(request, response, Seconds.seconds(20))
+        val action: ResponseServeAction = policy.serveResponse(request, response, Duration.ofSeconds(20))
         action should be(Validate(s"Response is stale, and stale response is not allowed", staleIfError = true))
       }
 
@@ -254,7 +254,7 @@ class ResponseServingCalculatorSpec extends WordSpec with ConversionCheckedTripl
         val responseHeaders = Map(`Cache-Control` -> Seq("max-age=10,stale-if-error=30"))
         val response = defaultResponse.copy(headers = defaultResponse.headers ++ responseHeaders)
 
-        val action: ResponseServeAction = policy.serveResponse(request, response, Seconds.seconds(60))
+        val action: ResponseServeAction = policy.serveResponse(request, response, Duration.ofSeconds(60))
         action should be(Validate(s"Response is stale, and stale response is not allowed", staleIfError = false))
       }
     }
@@ -272,7 +272,7 @@ class ResponseServingCalculatorSpec extends WordSpec with ConversionCheckedTripl
         val request = defaultRequest
         val response = defaultResponse.copy(headers = defaultResponse.headers ++ headers)
 
-        val action: ResponseServeAction = policy.serveResponse(request, response, Seconds.seconds(60))
+        val action: ResponseServeAction = policy.serveResponse(request, response, Duration.ofSeconds(60))
         action should be(Validate("Response is stale, and stale response is not allowed"))
       }
 
@@ -287,7 +287,7 @@ class ResponseServingCalculatorSpec extends WordSpec with ConversionCheckedTripl
         val request = defaultRequest
         val response = defaultResponse.copy(headers = defaultResponse.headers ++ headers)
 
-        val action: ResponseServeAction = policy.serveResponse(request, response, Seconds.seconds(60))
+        val action: ResponseServeAction = policy.serveResponse(request, response, Duration.ofSeconds(60))
         action should be(ServeFresh("Fresh response: lifetime = PT600S, PT540S seconds left"))
       }
 
@@ -303,7 +303,7 @@ class ResponseServingCalculatorSpec extends WordSpec with ConversionCheckedTripl
         val request = defaultRequest
         val response = defaultResponse.copy(headers = defaultResponse.headers ++ headers)
 
-        val action: ResponseServeAction = policy.serveResponse(request, response, Seconds.seconds(60))
+        val action: ResponseServeAction = policy.serveResponse(request, response, Duration.ofSeconds(60))
         action should be(Validate("Response is stale, and stale response is not allowed"))
       }
 
@@ -319,7 +319,7 @@ class ResponseServingCalculatorSpec extends WordSpec with ConversionCheckedTripl
         val responseHeaders = Map(`Cache-Control` -> Seq("public, max-age=120, must-revalidate"))
         val response = defaultResponse.copy(headers = defaultResponse.headers ++ responseHeaders)
 
-        val action: ResponseServeAction = policy.serveResponse(request, response, Seconds.seconds(60))
+        val action: ResponseServeAction = policy.serveResponse(request, response, Duration.ofSeconds(60))
         action should be(ServeFresh("Fresh response: lifetime = PT120S, PT60S seconds left"))
       }
 
@@ -331,7 +331,7 @@ class ResponseServingCalculatorSpec extends WordSpec with ConversionCheckedTripl
         val responseHeaders = Map(`Cache-Control` -> Seq("public, max-age=120, must-revalidate"))
         val response = defaultResponse.copy(headers = defaultResponse.headers ++ responseHeaders)
 
-        val action: ResponseServeAction = policy.serveResponse(request, response, Seconds.seconds(300))
+        val action: ResponseServeAction = policy.serveResponse(request, response, Duration.ofSeconds(300))
         action should be(ValidateOrTimeout(s"Response is stale, response contains must-revalidate directive"))
       }
 
@@ -350,7 +350,7 @@ class ResponseServingCalculatorSpec extends WordSpec with ConversionCheckedTripl
         val responseHeaders = Map(`Cache-Control` -> Seq("max-age=120"))
         val response = defaultResponse.copy(headers = defaultResponse.headers ++ responseHeaders)
 
-        val action: ResponseServeAction = policy.serveResponse(request, response, Seconds.seconds(60))
+        val action: ResponseServeAction = policy.serveResponse(request, response, Duration.ofSeconds(60))
         action should be(ServeFresh("Fresh response: lifetime = PT120S, PT60S seconds left"))
       }
 
@@ -362,7 +362,7 @@ class ResponseServingCalculatorSpec extends WordSpec with ConversionCheckedTripl
         val responseHeaders = Map(`Cache-Control` -> Seq("max-age=120"))
         val response = defaultResponse.copy(headers = defaultResponse.headers ++ responseHeaders)
 
-        val action: ResponseServeAction = policy.serveResponse(request, response, Seconds.seconds(300))
+        val action: ResponseServeAction = policy.serveResponse(request, response, Duration.ofSeconds(300))
         action should be(Validate(s"Response is stale, and stale response is not allowed"))
       }
 
@@ -374,7 +374,7 @@ class ResponseServingCalculatorSpec extends WordSpec with ConversionCheckedTripl
         val responseHeaders = Map(`Cache-Control` -> Seq("max-age=0"))
         val response = defaultResponse.copy(headers = defaultResponse.headers ++ responseHeaders)
 
-        val action: ResponseServeAction = policy.serveResponse(request, response, Seconds.seconds(0))
+        val action: ResponseServeAction = policy.serveResponse(request, response, Duration.ofSeconds(0))
         action should be(Validate(s"Response is stale, and stale response is not allowed"))
       }
     }
@@ -391,7 +391,7 @@ class ResponseServingCalculatorSpec extends WordSpec with ConversionCheckedTripl
           val responseHeaders = Map(`Cache-Control` -> Seq("max-age=300,s-maxage=0"))
           val response = defaultResponse.copy(headers = defaultResponse.headers ++ responseHeaders)
 
-          val action: ResponseServeAction = policy.serveResponse(request, response, Seconds.seconds(0))
+          val action: ResponseServeAction = policy.serveResponse(request, response, Duration.ofSeconds(0))
           action should be(ServeFresh(s"Fresh response: lifetime = PT300S, PT300S seconds left"))
         }
 
@@ -403,7 +403,7 @@ class ResponseServingCalculatorSpec extends WordSpec with ConversionCheckedTripl
           val responseHeaders = Map(`Cache-Control` -> Seq("max-age=0,s-maxage=120"))
           val response = defaultResponse.copy(headers = defaultResponse.headers ++ responseHeaders)
 
-          val action: ResponseServeAction = policy.serveResponse(request, response, Seconds.seconds(60))
+          val action: ResponseServeAction = policy.serveResponse(request, response, Duration.ofSeconds(60))
           action should be(Validate(s"Response is stale, and stale response is not allowed"))
         }
 
@@ -424,7 +424,7 @@ class ResponseServingCalculatorSpec extends WordSpec with ConversionCheckedTripl
           val responseHeaders = Map(`Cache-Control` -> Seq("max-age=0,s-maxage=120"))
           val response = defaultResponse.copy(headers = defaultResponse.headers ++ responseHeaders)
 
-          val action: ResponseServeAction = policy.serveResponse(request, response, Seconds.seconds(60))
+          val action: ResponseServeAction = policy.serveResponse(request, response, Duration.ofSeconds(60))
           action should be(ServeFresh("Fresh response: lifetime = PT120S, PT60S seconds left"))
         }
 
@@ -438,7 +438,7 @@ class ResponseServingCalculatorSpec extends WordSpec with ConversionCheckedTripl
           val responseHeaders = Map(`Cache-Control` -> Seq("max-age=600, s-maxage=120"))
           val response = defaultResponse.copy(headers = defaultResponse.headers ++ responseHeaders)
 
-          val action: ResponseServeAction = policy.serveResponse(request, response, Seconds.seconds(300))
+          val action: ResponseServeAction = policy.serveResponse(request, response, Duration.ofSeconds(300))
           action should be(ValidateOrTimeout(s"Response is stale, response contains s-maxage directive and cache is shared"))
         }
 
@@ -458,7 +458,7 @@ class ResponseServingCalculatorSpec extends WordSpec with ConversionCheckedTripl
           val responseHeaders = Map(`Cache-Control` -> Seq("s-maxage=0"))
           val response = defaultResponse.copy(headers = defaultResponse.headers ++ responseHeaders)
 
-          val action: ResponseServeAction = policy.serveResponse(request, response, Seconds.seconds(0))
+          val action: ResponseServeAction = policy.serveResponse(request, response, Duration.ofSeconds(0))
           action should be(ValidateOrTimeout(s"Response is stale, response contains s-maxage directive and cache is shared"))
         }
       }
@@ -478,7 +478,7 @@ class ResponseServingCalculatorSpec extends WordSpec with ConversionCheckedTripl
         val responseHeaders = Map(`Cache-Control` -> Seq("public, max-age=120, proxy-revalidate"))
         val response = defaultResponse.copy(headers = defaultResponse.headers ++ responseHeaders)
 
-        val action: ResponseServeAction = policy.serveResponse(request, response, Seconds.seconds(60))
+        val action: ResponseServeAction = policy.serveResponse(request, response, Duration.ofSeconds(60))
         action should be(ServeFresh("Fresh response: lifetime = PT120S, PT60S seconds left"))
       }
 
@@ -493,7 +493,7 @@ class ResponseServingCalculatorSpec extends WordSpec with ConversionCheckedTripl
         //The "must-revalidate" response directive indicates that once it has
         //become stale, a cache MUST NOT use the response to satisfy subsequent
         //requests without successful validation on the origin server.
-        val action: ResponseServeAction = policy.serveResponse(request, response, Seconds.seconds(300))
+        val action: ResponseServeAction = policy.serveResponse(request, response, Duration.ofSeconds(300))
         action should be(ValidateOrTimeout(s"Response is stale, response contains proxy-revalidate directive and cache is shared"))
       }
 
@@ -508,7 +508,7 @@ class ResponseServingCalculatorSpec extends WordSpec with ConversionCheckedTripl
         //The "must-revalidate" response directive indicates that once it has
         //become stale, a cache MUST NOT use the response to satisfy subsequent
         //requests without successful validation on the origin server.
-        val action: ResponseServeAction = policy.serveResponse(request, response, Seconds.seconds(300))
+        val action: ResponseServeAction = policy.serveResponse(request, response, Duration.ofSeconds(300))
         action should be(Validate(s"Response is stale, and stale response is not allowed"))
       }
     }
@@ -523,7 +523,7 @@ class ResponseServingCalculatorSpec extends WordSpec with ConversionCheckedTripl
         val responseHeaders = Map(`Cache-Control` -> Seq("max-age=120, stale-while-revalidate=30"))
         val response = defaultResponse.copy(headers = defaultResponse.headers ++ responseHeaders)
 
-        val action: ResponseServeAction = policy.serveResponse(request, response, Seconds.seconds(30))
+        val action: ResponseServeAction = policy.serveResponse(request, response, Duration.ofSeconds(30))
         action should be(ServeFresh(s"Fresh response: lifetime = PT120S, PT90S seconds left"))
       }
 
@@ -535,7 +535,7 @@ class ResponseServingCalculatorSpec extends WordSpec with ConversionCheckedTripl
         val responseHeaders = Map(`Cache-Control` -> Seq("max-age=120, stale-while-revalidate=30"))
         val response = defaultResponse.copy(headers = defaultResponse.headers ++ responseHeaders)
 
-        val action: ResponseServeAction = policy.serveResponse(request, response, Seconds.seconds(130))
+        val action: ResponseServeAction = policy.serveResponse(request, response, Duration.ofSeconds(130))
         action should be(ServeStaleAndValidate(s"Response contains stale-while-revalidate and is within delta range PT30S"))
       }
 
@@ -547,7 +547,7 @@ class ResponseServingCalculatorSpec extends WordSpec with ConversionCheckedTripl
         val responseHeaders = Map(`Cache-Control` -> Seq("max-age=120, stale-while-revalidate=30"))
         val response = defaultResponse.copy(headers = defaultResponse.headers ++ responseHeaders)
 
-        val action: ResponseServeAction = policy.serveResponse(request, response, Seconds.seconds(300))
+        val action: ResponseServeAction = policy.serveResponse(request, response, Duration.ofSeconds(300))
         action should be(Validate(s"Response is stale, and stale response is not allowed"))
       }
 
@@ -558,7 +558,7 @@ class ResponseServingCalculatorSpec extends WordSpec with ConversionCheckedTripl
         val responseHeaders = Map(`Cache-Control` -> Seq("max-age=120, stale-while-revalidate=30, stale-if-error=600"))
         val response = defaultResponse.copy(headers = defaultResponse.headers ++ responseHeaders)
 
-        val action: ResponseServeAction = policy.serveResponse(request, response, Seconds.seconds(300))
+        val action: ResponseServeAction = policy.serveResponse(request, response, Duration.ofSeconds(300))
         action should be(Validate(s"Response is stale, and stale response is not allowed", staleIfError = true))
       }
     }
@@ -573,7 +573,7 @@ class ResponseServingCalculatorSpec extends WordSpec with ConversionCheckedTripl
         val responseHeaders = Map(`Cache-Control` -> Seq("max-age=120, stale-if-error=30"))
         val response = defaultResponse.copy(headers = defaultResponse.headers ++ responseHeaders)
 
-        val action: ResponseServeAction = policy.serveResponse(request, response, Seconds.seconds(30))
+        val action: ResponseServeAction = policy.serveResponse(request, response, Duration.ofSeconds(30))
         action should be(ServeFresh(s"Fresh response: lifetime = PT120S, PT90S seconds left"))
       }
 
@@ -585,7 +585,7 @@ class ResponseServingCalculatorSpec extends WordSpec with ConversionCheckedTripl
         val responseHeaders = Map(`Cache-Control` -> Seq("max-age=120, stale-if-error=30"))
         val response = defaultResponse.copy(headers = defaultResponse.headers ++ responseHeaders)
 
-        val action: ResponseServeAction = policy.serveResponse(request, response, Seconds.seconds(130))
+        val action: ResponseServeAction = policy.serveResponse(request, response, Duration.ofSeconds(130))
         action should be(Validate(s"Response is stale, and stale response is not allowed", staleIfError = true))
       }
 
@@ -598,7 +598,7 @@ class ResponseServingCalculatorSpec extends WordSpec with ConversionCheckedTripl
         val responseHeaders = Map(`Cache-Control` -> Seq("max-age=120, stale-if-error=30"))
         val response = defaultResponse.copy(headers = defaultResponse.headers ++ responseHeaders)
 
-        val action: ResponseServeAction = policy.serveResponse(request, response, Seconds.seconds(200))
+        val action: ResponseServeAction = policy.serveResponse(request, response, Duration.ofSeconds(200))
         action should be(Validate(s"Response is stale, and stale response is not allowed", staleIfError = false))
       }
 

--- a/src/test/scala/com/typesafe/play/cachecontrol/SecondaryKeyCalculatorSpec.scala
+++ b/src/test/scala/com/typesafe/play/cachecontrol/SecondaryKeyCalculatorSpec.scala
@@ -3,8 +3,9 @@
  */
 package com.typesafe.play.cachecontrol
 
+import java.time.Duration
+
 import HeaderNames._
-import org.joda.time.Seconds
 import org.scalatest.Matchers._
 import org.scalatest.WordSpec
 
@@ -12,7 +13,7 @@ class SecondaryKeyCalculatorSpec extends WordSpec {
 
   def responseHeaders = {
     val now = HttpDate.now
-    val age = Seconds.seconds(60)
+    val age = Duration.ofSeconds(60)
     val headers = Map(
       `Date` -> Seq(HttpDate.format(now)),
       `Age` -> Seq(age.getSeconds.toString),

--- a/src/test/scala/com/typesafe/play/cachecontrol/StubCache.scala
+++ b/src/test/scala/com/typesafe/play/cachecontrol/StubCache.scala
@@ -3,8 +3,6 @@
  */
 package com.typesafe.play.cachecontrol
 
-import org.joda.time.Seconds
-
 class StubCache(shared: Boolean) extends CacheDefaults {
 
   override def isShared: Boolean = shared


### PR DESCRIPTION
This is discussable since:
- it only works on java8
- it will need a major version upgrade
- it creates a shim over `java.time.Duration` to strip all unnecessary fields (nanos, millis)

The question is also if this should be in 2.7.x since that will remove joda, in most libraries and put that into external library's.