### PR TITLE
Change version to 2.0.0-SNAPSHOT

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.1.4-SNAPSHOT"
+version in ThisBuild := "2.0.0-SNAPSHOT"


### PR DESCRIPTION
I've just made a new 1.1.x branch to track the stable version of cachecontrol and master should now be 2.0.x. This PR bumps the version. Although trivial, I'm making a PR to see if the Travis checks pass (they previously weren't enabled).