### PR TITLE
drop scala 2.10 and add support for 2.13.0-M4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ sudo: false
 group: beta
 scala:
 - 2.11.12
-- 2.12.4
-- 2.13.0-M4
+- 2.12.8
+- 2.13.0-M5
 jdk:
 - oraclejdk8
-- oraclejdk9
+- openjdk11
 cache:
   directories:
   - "$HOME/.ivy2/cache"
@@ -21,8 +21,7 @@ notifications:
   slack:
     secure: J6SqDQgrnauTDSeiRCsMyYqCQDzF1gPbgVX1yTgnqUhyDJYIR5js4W3ufLUAwQCtI7fxj46Kca97ZcEC9ttnC/qD6RV+pUeszbQIBMcIZtH83R/vZaYaFIYNOLWHkFk38cglpYw2bhzMx3vSW4QT6LUyhJqSfDuQVWfB1RT6PE8=
 matrix:
+  fast_finish: true
   exclude:
-    - scala: 2.10.7
-      jdk: oraclejdk9
     - scala: 2.11.12
-      jdk: oraclejdk9
+      jdk: openjdk11

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,9 @@ dist: trusty
 sudo: false
 group: beta
 scala:
-- 2.10.7
 - 2.11.12
 - 2.12.4
-- 2.13.0-M3
+- 2.13.0-M4
 jdk:
 - oraclejdk8
 - oraclejdk9

--- a/build.sbt
+++ b/build.sbt
@@ -4,9 +4,9 @@ name := "cachecontrol"
 
 organization := "com.typesafe.play"
 
-scalaVersion := "2.12.4"
+scalaVersion := "2.12.8"
 
-crossScalaVersions := Seq("2.12.4", "2.11.12", "2.13.0-M4")
+crossScalaVersions := Seq("2.12.8", "2.11.12", "2.13.0-M5")
 
 libraryDependencies := {
   CrossVersion.partialVersion(scalaVersion.value) match {

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ organization := "com.typesafe.play"
 
 scalaVersion := "2.12.4"
 
-crossScalaVersions := Seq("2.12.4", "2.11.12", "2.10.7", "2.13.0-M3")
+crossScalaVersions := Seq("2.12.4", "2.11.12", "2.13.0-M4")
 
 libraryDependencies := {
   CrossVersion.partialVersion(scalaVersion.value) match {
@@ -18,7 +18,7 @@ libraryDependencies := {
   }
 }
 
-libraryDependencies ++= scalaTest ++ slf4j
+libraryDependencies ++= scalaTest ++ slf4j ++ scalaCollectionCompat
 
 libraryDependencies += "org.slf4j" % "slf4j-simple" % slf4jVersion % Test
 

--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ libraryDependencies := {
   }
 }
 
-libraryDependencies ++= scalaTest ++ slf4j ++ scalaCollectionCompat
+libraryDependencies ++= scalaTest ++ slf4j
 
 libraryDependencies += "org.slf4j" % "slf4j-simple" % slf4jVersion % Test
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,15 +5,7 @@ import sbt._
 
 object Dependencies {
 
-  val scalaTestVersion = "3.0.6-SNAP5"
-
-  val scalaCollectionCompat = Seq(
-    "org.scala-lang.modules" %% "scala-collection-compat" % "0.2.1"
-  )
-
-  val scalaTest = Seq(
-    "org.scalatest" %% "scalatest" % scalaTestVersion % "test"
-  )
+  def scalaTest = Seq("org.scalatest" %% "scalatest" % "3.0.6-SNAP5" % "test")
 
   val parserCombinatorVersion = "1.1.1"
   val parserCombinators = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,10 +5,10 @@ import sbt._
 
 object Dependencies {
 
-  val scalaTestVersion = "3.0.6-SNAP1"
+  val scalaTestVersion = "3.0.6-SNAP5"
 
   val scalaCollectionCompat = Seq(
-    "org.scala-lang.modules" %% "scala-collection-compat" % "0.1.1"
+    "org.scala-lang.modules" %% "scala-collection-compat" % "0.2.1"
   )
 
   val scalaTest = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,13 +5,17 @@ import sbt._
 
 object Dependencies {
 
-  val scalaTestVersion = "3.0.5-M1"
+  val scalaTestVersion = "3.0.6-SNAP1"
+
+  val scalaCollectionCompat = Seq(
+    "org.scala-lang.modules" %% "scala-collection-compat" % "0.1.1"
+  )
 
   val scalaTest = Seq(
     "org.scalatest" %% "scalatest" % scalaTestVersion % "test"
   )
 
-  val parserCombinatorVersion = "1.1.0"
+  val parserCombinatorVersion = "1.1.1"
   val parserCombinators = Seq(
     "org.scala-lang.modules" %% "scala-parser-combinators" % parserCombinatorVersion
   )

--- a/src/main/scala-2.11/cachecontrol/CacheDirectiveParserCompat.scala
+++ b/src/main/scala-2.11/cachecontrol/CacheDirectiveParserCompat.scala
@@ -1,0 +1,10 @@
+/*
+ * Copyright (C) 2015-2017 Lightbend, Inc. All rights reserved.
+ */
+package com.typesafe.play.cachecontrol
+
+object CacheDirectiveParserCompat {
+  def toImmutableSeq[T](seq: Seq[T]): scala.collection.immutable.Seq[T] = {
+    seq.to[scala.collection.immutable.Seq]
+  }
+}

--- a/src/main/scala-2.12/com/typesafe/play/cachecontrol/CacheDirectiveParserCompat.scala
+++ b/src/main/scala-2.12/com/typesafe/play/cachecontrol/CacheDirectiveParserCompat.scala
@@ -1,0 +1,10 @@
+/*
+ * Copyright (C) 2015-2017 Lightbend, Inc. All rights reserved.
+ */
+package com.typesafe.play.cachecontrol
+
+object CacheDirectiveParserCompat {
+  def toImmutableSeq[T](seq: Seq[T]): scala.collection.immutable.Seq[T] = {
+    seq.to[scala.collection.immutable.Seq]
+  }
+}

--- a/src/main/scala-2.13.0-M5/com/typesafe/play/cachecontrol/CacheDirectiveParserCompat.scala
+++ b/src/main/scala-2.13.0-M5/com/typesafe/play/cachecontrol/CacheDirectiveParserCompat.scala
@@ -1,0 +1,12 @@
+/*
+ * Copyright (C) 2015-2017 Lightbend, Inc. All rights reserved.
+ */
+package com.typesafe.play.cachecontrol
+
+import org.slf4j.LoggerFactory
+
+object CacheDirectiveParserCompat {
+  def toImmutableSeq[T](seq: Seq[T]): scala.collection.immutable.Seq[T] = {
+    seq.to(scala.collection.immutable.Seq)
+  }
+}

--- a/src/main/scala/com/typesafe/play/cachecontrol/CacheDirectiveParser.scala
+++ b/src/main/scala/com/typesafe/play/cachecontrol/CacheDirectiveParser.scala
@@ -5,7 +5,6 @@ package com.typesafe.play.cachecontrol
 
 import org.slf4j.LoggerFactory
 
-import scala.collection.compat._
 import scala.collection.immutable.BitSet
 import scala.util.parsing.combinator.Parsers
 import scala.util.parsing.input.CharSequenceReader
@@ -18,7 +17,7 @@ import scala.util.parsing.input.CharSequenceReader
 object CacheDirectiveParser {
 
   def parse(headers: Seq[String]): collection.immutable.Seq[CacheDirective] = {
-    headers.flatMap(parse).to(collection.immutable.Seq)
+    CacheDirectiveParserCompat.toImmutableSeq(headers.flatMap(parse))
   }
 
   def parse(header: String): collection.immutable.Seq[CacheDirective] = {

--- a/src/main/scala/com/typesafe/play/cachecontrol/CacheDirectiveParser.scala
+++ b/src/main/scala/com/typesafe/play/cachecontrol/CacheDirectiveParser.scala
@@ -5,6 +5,7 @@ package com.typesafe.play.cachecontrol
 
 import org.slf4j.LoggerFactory
 
+import scala.collection.compat._
 import scala.collection.immutable.BitSet
 import scala.util.parsing.combinator.Parsers
 import scala.util.parsing.input.CharSequenceReader
@@ -17,7 +18,7 @@ import scala.util.parsing.input.CharSequenceReader
 object CacheDirectiveParser {
 
   def parse(headers: Seq[String]): collection.immutable.Seq[CacheDirective] = {
-    headers.flatMap(parse).to[collection.immutable.Seq]
+    headers.flatMap(parse).to(collection.immutable.Seq)
   }
 
   def parse(header: String): collection.immutable.Seq[CacheDirective] = {


### PR DESCRIPTION
actually we should drop support for 2.10 with the 2.13 release series.
first of all scala-collection-compat is only available for 2.11, 2.12 and 2.13 and also supporting three scala flavors should be more than enough.