### PR TITLE
[1.1.x]: Build using AdoptOpenJDK 8 & 11 (#38)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,48 @@
 language: scala
-dist: trusty
-sudo: false
-group: beta
+
+before_install:
+  - curl -sL https://github.com/shyiko/jabba/raw/master/install.sh | bash && . ~/.jabba/jabba.sh
+
+install:
+  - $JABBA_HOME/bin/jabba install $TRAVIS_JDK
+  - unset _JAVA_OPTIONS
+  - export JAVA_HOME="$JABBA_HOME/jdk/$TRAVIS_JDK" && export PATH="$JAVA_HOME/bin:$PATH" && java -Xmx32m -version
+
+env:
+  global:
+    - JABBA_HOME=$HOME/.jabba
+  matrix:
+    - TRAVIS_JDK=adopt@1.8.192-12
+    - TRAVIS_JDK=adopt@1.11.0-1
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    # Java 11 is still not fully supported. It is good that we are already
+    # testing cachecontrol using it to better discover possible problems but
+    # we can allow failures here too.
+    - env: TRAVIS_JDK=adopt@1.11.0-1
+
 scala:
-- 2.11.12
-- 2.12.8
-- 2.13.0-M5
-jdk:
-- oraclejdk8
-- openjdk11
+  - 2.11.12
+  - 2.12.8
+  - 2.13.0-M5
+
+script:
+  - sbt ++$TRAVIS_SCALA_VERSION scalastyle test mimaReportBinaryIssues
+
 cache:
   directories:
-  - "$HOME/.ivy2/cache"
-  - "$HOME/.sbt/boot/"
-script:
-- sbt ++$TRAVIS_SCALA_VERSION scalastyle test mimaReportBinaryIssues
+    - "$HOME/.ivy2/cache"
+    - "$HOME/.sbt/boot/"
+    - "$HOME/.jabba/jdk"
+
 before_cache:
-- find $HOME/.ivy2/cache -name "ivydata-*.properties" | xargs rm
+  - rm -rf $HOME/.ivy2/cache/com.typesafe.play/*
+  - rm -rf $HOME/.ivy2/cache/scala_*/sbt_*/com.typesafe.play/*
+  - find $HOME/.ivy2 -name "ivydata-*.properties" -delete
+  - find $HOME/.sbt -name "*.lock" -delete
+
 notifications:
   slack:
     secure: J6SqDQgrnauTDSeiRCsMyYqCQDzF1gPbgVX1yTgnqUhyDJYIR5js4W3ufLUAwQCtI7fxj46Kca97ZcEC9ttnC/qD6RV+pUeszbQIBMcIZtH83R/vZaYaFIYNOLWHkFk38cglpYw2bhzMx3vSW4QT6LUyhJqSfDuQVWfB1RT6PE8=
-matrix:
-  fast_finish: true
-  exclude:
-    - scala: 2.11.12
-      jdk: openjdk11

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,4 +1,4 @@
 #
 # Copyright (C) 2015-2017 Lightbend, Inc. All rights reserved.
 #
-sbt.version=1.1.1
+sbt.version=1.2.8


### PR DESCRIPTION
Backport #38.