### PR TITLE
scala-parser-combinators 2.4.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,7 @@ object Dependencies {
     "org.scala-lang.modules" %% "scala-parser-combinators" % {
       CrossVersion.partialVersion(scalaVersion) match {
         case Some((2, _)) => "1.1.2"
-        case _            => "2.3.0"
+        case _            => "2.4.0"
       }
     }
 


### PR DESCRIPTION
Merge into main after we created a `3.0.x` branch.