### PR TITLE
scala-parser-combinators v1 for Scala 2.12, v2 for 2.13+

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,8 +15,8 @@ object Dependencies {
   def parserCombinators(scalaVersion: String) =
     "org.scala-lang.modules" %% "scala-parser-combinators" % {
       CrossVersion.partialVersion(scalaVersion) match {
-        case Some((2, _)) => "1.1.2"
-        case _            => "2.4.0"
+        case Some((2, 12)) => "1.1.2"
+        case _             => "2.4.0"
       }
     }
 


### PR DESCRIPTION
- Needed for https://github.com/playframework/playframework/pull/13197
- See https://github.com/playframework/playframework/issues/13179
- [ ] Need to bump in play-ws