### PR TITLE
Fix warnings

### DIFF
--- a/src/main/scala/org/playframework/cachecontrol/VaryParser.scala
+++ b/src/main/scala/org/playframework/cachecontrol/VaryParser.scala
@@ -12,7 +12,7 @@ object VaryParser {
     if (fieldValue.startsWith("*")) {
       List(HeaderName("*"))
     } else {
-      val headerNames = fieldValue.split(",\\s*").map(HeaderName)
+      val headerNames = fieldValue.split(",\\s*").map(HeaderName.apply)
       headerNames.toList
     }
   }

--- a/src/main/scala/org/playframework/cachecontrol/WarningParser.scala
+++ b/src/main/scala/org/playframework/cachecontrol/WarningParser.scala
@@ -33,11 +33,11 @@ object WarningParser {
 
     val warnAgent = regex("\\S+".r) <~ space
 
-    val warnText = stringLiteral ^^ { s => s.replaceAllLiterally('"'.toString, "") }
+    val warnText = stringLiteral ^^ { s => s.replace('"'.toString, "") }
 
     val warnDate = opt(space ~> stringLiteral) ^^ { maybeString =>
       maybeString.map { s =>
-        val chomp = s.replaceAllLiterally('"'.toString, "")
+        val chomp = s.replace('"'.toString, "")
         HttpDate.parse(chomp)
       }
     }


### PR DESCRIPTION
```
[warn] -- Warning: /home/runner/work/cachecontrol/cachecontrol/src/main/scala/org/playframework/cachecontrol/VaryParser.scala:15:54 
[warn] 15 |      val headerNames = fieldValue.split(",\\s*").map(HeaderName)
[warn]    |                                                      ^^^^^^^^^^
[warn]    |The method `apply` is inserted. The auto insertion will be deprecated, please write `org.playframework.cachecontrol.HeaderName.apply` explicitly.
[warn] -- Deprecation Warning: /home/runner/work/cachecontrol/cachecontrol/src/main/scala/org/playframework/cachecontrol/WarningParser.scala:36:45 
[warn] 36 |    val warnText = stringLiteral ^^ { s => s.replaceAllLiterally('"'.toString, "") }
[warn]    |                                           ^^^^^^^^^^^^^^^^^^^^^
[warn]    |method replaceAllLiterally in class StringOps is deprecated since 2.13.2: Use `s.replace` as an exact replacement
[warn] -- Deprecation Warning: /home/runner/work/cachecontrol/cachecontrol/src/main/scala/org/playframework/cachecontrol/WarningParser.scala:40:22 
[warn] 40 |        val chomp = s.replaceAllLiterally('"'.toString, "")
[warn]    |                    ^^^^^^^^^^^^^^^^^^^^^
[warn]    |method replaceAllLiterally in class StringOps is deprecated since 2.13.2: Use `s.replace` as an exact replacement
```